### PR TITLE
change GetElementPtrInst to GEPOperator

### DIFF
--- a/analyzer/src/lib/CallGraph.cc
+++ b/analyzer/src/lib/CallGraph.cc
@@ -417,9 +417,8 @@ Value *CallGraphPass:: nextLayerBaseType(Value *V, Type * &BTy,
 
 	// Two ways to get the next layer type: GetElementPtrInst and
 	// LoadInst
-	// Case 1: GetElementPtrInst
-	if (GetElementPtrInst *GEP 
-			= dyn_cast<GetElementPtrInst>(V)) {
+	// Case 1: GetElementPtrInst and ConstantExpr
+	if (auto GEP = dyn_cast<GEPOperator>(V)) {
 		Type *PTy = GEP->getPointerOperand()->getType();
 		Type *Ty = PTy->getPointerElementType();
 		if ((Ty->isStructTy() || Ty->isArrayTy() || Ty->isVectorTy()) 


### PR DESCRIPTION
I think _ConstantExpr_ needs to be considered here.
e.g.
%0 = load void (i8*, i8*)*, void (i8*, i8*)** getelementptr inbounds (%struct.C, %struct.C* @c, i32 0, i32 0, i32 0), align 8

So in order to unify, use _GEPOperator_ instead.